### PR TITLE
make the help window full screen and resize it when the game resizes

### DIFF
--- a/src/help.cpp
+++ b/src/help.cpp
@@ -162,10 +162,8 @@ void help_window::draw_category_selection()
     format_title( _( "Help" ) );
     // Split the categories in half
     if( ImGui::BeginTable( "Category Options", 2, ImGuiTableFlags_None ) ) {
-        ImGui::TableSetupColumn( "Left Column", ImGuiTableColumnFlags_WidthStretch,
-                                 static_cast<float>( window_width / 2.0f ) );
-        ImGui::TableSetupColumn( "Right Column", ImGuiTableColumnFlags_WidthStretch,
-                                 static_cast<float>( window_width / 2.0f ) );
+        ImGui::TableSetupColumn( "Left Column", ImGuiTableColumnFlags_WidthStretch, 1.0f );
+        ImGui::TableSetupColumn( "Right Column", ImGuiTableColumnFlags_WidthStretch, 1.0f );
         int half_size = static_cast<float>( data.help_categories.size() / 2.0f ) + 1;
         auto half_it = data.help_categories.begin();
         std::advance( half_it, half_size );
@@ -306,7 +304,7 @@ void help_window::draw_category()
                 continue;
             } else if( translated_paragraph == "<HELP_DRAW_DIRECTIONS>" ) {
                 static const std::string dir_grid = get_dir_grid();
-                cataimgui::draw_colored_text( dir_grid, wrap_width );
+                cataimgui::draw_colored_text( dir_grid );
                 continue;
             }
             cataimgui::TextColoredParagraph( c_white, translated_paragraph );
@@ -348,7 +346,7 @@ void help_window::parse_tags_help_window()
 
 cataimgui::bounds help_window::get_bounds()
 {
-    return bounds;
+    return {0, 0, 1.0, 1.0};
 }
 
 void help_window::show()

--- a/src/help.h
+++ b/src/help.h
@@ -55,18 +55,6 @@ class help_window : public cataimgui::window
         void draw_controls() override;
         cataimgui::bounds get_bounds() override;
     private:
-        // Fullscreen
-        float window_width = static_cast<float>( str_width_to_pixels( TERMX ) );
-        float window_height = static_cast<float>( str_width_to_pixels( TERMY ) );
-        float wrap_width = window_width * 0.95f;
-        cataimgui::bounds bounds{ 0.f, 0.f, static_cast<float>( str_width_to_pixels( TERMX ) ), static_cast<float>( str_height_to_pixels( TERMY ) ) };
-
-        // 66 is optimal characters per line for reading?
-        //float window_width = static_cast<float>( wrap_width ) * 2.025f;
-        //float window_height = static_cast<float>( str_width_to_pixels( TERMY ) ) * 0.8f;
-        //float wrap_width = std::min( window_width * 0.95f, static_cast<float>( str_width_to_pixels( 66 ) ) );
-        //cataimgui::bounds bounds{ 0.f, 0.f, window_width, window_height };
-
         help &data = get_help();
         input_context ctxt;
         std::map<int, input_event> hotkeys;


### PR DESCRIPTION
We do this by not specifying the size in pixels but in percent. We want the window to be 100%, or 1.0×, the size of the game window.